### PR TITLE
chore(dev.yml): update secrets variables to use PKG_GITHUB_USERNAME and PKG_GITHUB_TOKEN for consistency

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,8 +11,10 @@ jobs:
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
+      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -1,14 +1,14 @@
-name: Sec
+name: Security Analysis Workflow
 
 on: [push]
 
 jobs:
-  Sec:
+  sec:
     uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
chore(sec.yml): rename job name to 'sec' and update secrets variables to use PKG_GITHUB_USERNAME and PKG_GITHUB_TOKEN for consistency The changes were made to ensure consistency in the naming of secrets variables across different workflows. By updating the secrets variables to use PKG_GITHUB_USERNAME and PKG_GITHUB_TOKEN, it makes the configuration more uniform and easier to manage.