### PR TITLE
build: add additional Maven repositories for dependencies resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION = $(shell cat VERSION)
+
 GATEWAY_NAME	   	:= komune-io/fs-gateway
 GATEWAY_IMG	    	:= ${GATEWAY_NAME}:${VERSION}
 GATEWAY_PACKAGE	   	:= fs-api:api-gateway

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,13 @@ plugins {
 allprojects {
 	group = "io.komune.fs"
 	version = System.getenv("VERSION") ?: "latest"
+
+	repositories {
+		mavenCentral()
+		mavenLocal()
+		maven { url = uri("https://s01.oss.sonatype.org/service/local/repositories/releases/content") }
+		maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	}
 }
 
 fixers {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,3 +5,10 @@ plugins {
 dependencies {
 	implementation("io.komune.fixers.gradle:dependencies:0.17.0-SNAPSHOT")
 }
+
+repositories {
+	mavenCentral()
+	mavenLocal()
+	maven { url = uri("https://s01.oss.sonatype.org/service/local/repositories/releases/content") }
+	maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,13 @@
+pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		mavenLocal()
+		mavenCentral()
+		maven { url = uri("https://s01.oss.sonatype.org/service/local/repositories/releases/content") }
+		maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	}
+}
+
 rootProject.name = "connect-fs"
 
 include(


### PR DESCRIPTION
The changes in the build.gradle.kts, buildSrc/build.gradle.kts, and settings.gradle.kts files involve adding additional Maven repositories for dependencies resolution. By including these repositories, the project gains access to a wider range of dependencies hosted in different repositories, improving the chances of successful dependency resolution and build process.