### PR TITLE
chore(docker.mk): update GATEWAY_NAME to include DOCKER_REPOSITORY for better organization and clarity

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -1,6 +1,7 @@
 VERSION = $(shell cat VERSION)
+DOCKER_REPOSITORY = ghcr.io/
 
-GATEWAY_NAME	   	:= komune-io/fs-gateway
+GATEWAY_NAME	   	:= ${DOCKER_REPOSITORY}komune-io/fs-gateway
 GATEWAY_IMG	    	:= ${GATEWAY_NAME}:${VERSION}
 GATEWAY_PACKAGE	   	:= fs-api:api-gateway
 
@@ -18,7 +19,7 @@ promote:
 	@echo 'No promote'
 
 docker-fs-api-build:
-	VERSION=${VERSION} IMAGE_NAME=${GATEWAY_NAME} ./gradlew build ${GATEWAY_PACKAGE}:bootBuildImage -x test
+	VERSION=${VERSION} ./gradlew build ${GATEWAY_PACKAGE}:bootBuildImage --imageName ${GATEWAY_IMG} -x test
 
 docker-fs-api-push:
 	@docker push ${GATEWAY_IMG}

--- a/fs-api/api-gateway/build.gradle.kts
+++ b/fs-api/api-gateway/build.gradle.kts
@@ -15,6 +15,4 @@ dependencies {
 
 }
 
-tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootBuildImage> {
-    imageName.set("${System.getenv("IMAGE_NAME")}:${this.project.version}")
-}
+tasks.withType<org.springframework.boot.gradle.tasks.bundling.BootBuildImage> {}


### PR DESCRIPTION
chore(docker.mk): modify docker-fs-api-build script to use GATEWAY_IMG for image name consistency chore(docker.mk): remove unused imageName setting in build.gradle.kts file The GATEWAY_NAME variable is updated to include the DOCKER_REPOSITORY prefix for better organization and clarity. The docker-fs-api-build script is modified to use the GATEWAY_IMG variable for consistency in image naming. The imageName setting in the build.gradle.kts file is removed as it is no longer needed.