### PR TITLE
build(dev.yml): update the fixers-gradle workflow to a specific commit hash and add docker registry login

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,10 +1,16 @@
 name: Dev
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+  push:
+    branches:
+      - main
+      - 'release/*'
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@e969a95dd8dc2f7622cbda9669d375924bea1042
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,10 +4,12 @@ on: [push]
 
 jobs:
   dev:
-    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@e969a95dd8dc2f7622cbda9669d375924bea1042
     permissions:
       contents: read
       packages: write
+    with:
+      with-docker-registry-login: 'true'
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -1,6 +1,13 @@
 name: Security Analysis Workflow
 
-on: [push]
+on:
+  pull_request:
+    types: [opened, synchronize, labeled]
+  push:
+    branches:
+      - main
+      - 'release/*'
+
 
 jobs:
   sec:


### PR DESCRIPTION
The workflow now uses a specific commit hash (e969a95dd8dc2f7622cbda9669d375924bea1042) of the fixers-gradle workflow file to ensure consistency and stability. Additionally, a new parameter 'with-docker-registry-login' has been added to enable Docker registry login within the workflow for improved security and access control.