### PR TITLE
fix(dev.yml): update DOCKER_PROMOTE_USERNAME to use secrets instead of github context

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,7 +37,7 @@ jobs:
       PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
       DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ github.DOCKER_IO_USERNAME }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
       DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
 
   docs:


### PR DESCRIPTION
The DOCKER_PROMOTE_USERNAME variable is now updated to use the secrets.DOCKER_IO_USERNAME instead of github.DOCKER_IO_USERNAME to ensure sensitive information is not exposed in the workflow file.