### PR TITLE
chore(docker.mk): rename docker-fs-api-push to docker-fs-api-publish for clarity

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -13,14 +13,17 @@ build: docker-fs-api-build
 test:
 	@echo 'No test'
 
-publish: docker-fs-api-push
+publish: docker-fs-api-publish
 
-promote:
-	@echo 'No promote'
+promote: docker-fs-api-promote
 
 docker-fs-api-build:
 	VERSION=${VERSION} ./gradlew build ${GATEWAY_PACKAGE}:bootBuildImage --imageName ${GATEWAY_IMG} -x test
 
-docker-fs-api-push:
-	@docker push ${GATEWAY_IMG}
+docker-fs-api-publish:
+	@docker tag ${GATEWAY_IMG} ghcr.io/komune-io/${GATEWAY_IMG}
+	@docker push ghcr.io/komune-io/${CCCEV_APP_IMG}
 
+docker-fs-api-promote:
+	@docker tag ${GATEWAY_IMG} ghcr.io/komune-io/${GATEWAY_IMG}
+	@docker push docker.io/komune/${GATEWAY_IMG}


### PR DESCRIPTION
feat(docker.mk): add docker-fs-api-promote target to promote docker image to different registries The target docker-fs-api-push has been renamed to docker-fs-api-publish for better clarity and consistency with the purpose of the target. Additionally, two new targets, docker-fs-api-publish and docker-fs-api-promote, have been added to facilitate the publishing and promotion of docker images to different registries, improving the deployment process.