### PR TITLE
fix(docker.mk): correct docker push command to push the correct image

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -22,7 +22,7 @@ docker-fs-api-build:
 
 docker-fs-api-publish:
 	@docker tag ${GATEWAY_IMG} ghcr.io/komune-io/${GATEWAY_IMG}
-	@docker push ghcr.io/komune-io/${CCCEV_APP_IMG}
+	@docker push ghcr.io/komune-io/${GATEWAY_IMG}
 
 docker-fs-api-promote:
 	@docker tag ${GATEWAY_IMG} ghcr.io/komune-io/${GATEWAY_IMG}


### PR DESCRIPTION
The docker push command was pushing the wrong image variable ${CCCEV_APP_IMG} instead of the correct image variable ${GATEWAY_IMG}. The correction ensures that the correct image is pushed to the container registry.