### PR TITLE
chore(docker.mk): remove DOCKER_REPOSITORY prefix from GATEWAY_NAME variable

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -1,7 +1,7 @@
 VERSION = $(shell cat VERSION)
 DOCKER_REPOSITORY = ghcr.io/
 
-GATEWAY_NAME	   	:= ${DOCKER_REPOSITORY}komune-io/fs-gateway
+GATEWAY_NAME	   	:= fs-gateway
 GATEWAY_IMG	    	:= ${GATEWAY_NAME}:${VERSION}
 GATEWAY_PACKAGE	   	:= fs-api:api-gateway
 


### PR DESCRIPTION
The DOCKER_REPOSITORY prefix is removed from the GATEWAY_NAME variable to simplify the naming convention and make it more concise.