### PR TITLE
ci(dev.yml): add trigger for all tags to run the dev workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,15 +7,18 @@ on:
     branches:
       - main
       - 'release/*'
+    tags:
+      - '*'
 
 jobs:
-  dev:
+  libs:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
     permissions:
       contents: read
       packages: write
     with:
       make-file: 'libs.mk'
+      on-tag: 'promote'
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
@@ -48,10 +51,15 @@ jobs:
       pages: write
       id-token: write
     with:
+      on-tag: 'publish_promote'
       with-chromatic: false
       storybook-dir: storybook
       storybook-static-dir: storybook-static
-      with-setup-npm-github-pkg: 'true'
+      with-setup-npm-github-pkg: 'false'
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
+      DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}


### PR DESCRIPTION
By adding the tags trigger with the wildcard '*', the dev workflow will now be triggered for all tags in addition to the main branch and release branches. This change allows the workflow to run for any tagged releases or versions, providing more comprehensive coverage for the CI/CD process.