### PR TITLE
fix(FileEndpoint.kt, FileUploadCommand.kt, FileUtils.kt): change vectorize parameter type to nullable Boolean to allow for optional value

### DIFF
--- a/fs-s2/file/fs-file-app/src/main/kotlin/io/komune/fs/s2/file/app/FileEndpoint.kt
+++ b/fs-s2/file/fs-file-app/src/main/kotlin/io/komune/fs/s2/file/app/FileEndpoint.kt
@@ -208,7 +208,7 @@ class FileEndpoint(
             metadata = cmd.metadata.plus("id" to fileId)
         )
 
-        if (cmd.vectorize) {
+        if (cmd.vectorize ?: false) {
             vectorize(cmd.path, cmd.metadata, fileByteArray)
         }
 

--- a/fs-s2/file/fs-file-domain/src/commonMain/kotlin/io/komune/fs/s2/file/domain/features/command/FileUploadCommand.kt
+++ b/fs-s2/file/fs-file-domain/src/commonMain/kotlin/io/komune/fs/s2/file/domain/features/command/FileUploadCommand.kt
@@ -35,7 +35,7 @@ data class FileUploadCommand(
 	 * /!\ The vector store API url needs to be configured for this to work.
 	 * @example false
 	 */
-	val vectorize: Boolean = false
+	val vectorize: Boolean? = false
 )
 
 /**

--- a/fs-spring/fs-spring-utils/src/main/kotlin/io/komune/fs/spring/utils/FileUtils.kt
+++ b/fs-spring/fs-spring-utils/src/main/kotlin/io/komune/fs/spring/utils/FileUtils.kt
@@ -12,7 +12,7 @@ import java.util.Base64
 
 fun FilePath.toUploadCommand(
     metadata: Map<String, String> = emptyMap(),
-    vectorize: Boolean = false
+    vectorize: Boolean? = false
 ) = FileUploadCommand(
     path = this,
     metadata = mapOf(


### PR DESCRIPTION
The vectorize parameter in the FileEndpoint class, FileUploadCommand data class, and FileUtils.kt file has been changed from a non-nullable Boolean to a nullable Boolean type. This change allows for the vectorize parameter to be optional, providing more flexibility in how it can be used within the application.