### PR TITLE
fix(build.gradle.kts): update dependencies version to 0.19.0-SNAPSHOT

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-	implementation("io.komune.fixers.gradle:dependencies:0.18.0")
+	implementation("io.komune.fixers.gradle:dependencies:0.19.0-SNAPSHOT")
 }
 
 repositories {


### PR DESCRIPTION
The dependencies version has been updated to 0.19.0-SNAPSHOT to incorporate the latest changes and improvements provided by the library.