### PR TITLE
Add Serializable missing annotation

### DIFF
--- a/fs-s2/file/fs-file-domain/src/commonMain/kotlin/io/komune/fs/s2/file/domain/features/command/FileDeleteCommand.kt
+++ b/fs-s2/file/fs-file-domain/src/commonMain/kotlin/io/komune/fs/s2/file/domain/features/command/FileDeleteCommand.kt
@@ -18,6 +18,7 @@ typealias FileDeleteFunction = F2Function<FileDeleteCommand, FileDeletedEvents>
  * @d2 command
  * @parent [FileDeleteFunction]
  */
+@Serializable
 data class FileDeleteCommand(
 	/**
 	 * @ref [io.komune.fs.s2.file.domain.model.FilePath.objectType]

--- a/fs-s2/file/fs-file-domain/src/commonMain/kotlin/io/komune/fs/s2/file/domain/features/query/FileDownloadQuery.kt
+++ b/fs-s2/file/fs-file-domain/src/commonMain/kotlin/io/komune/fs/s2/file/domain/features/query/FileDownloadQuery.kt
@@ -17,6 +17,7 @@ typealias FileDownloadFunction = F2Function<FileDownloadQuery, FileDownloadResul
  * @d2 query
  * @parent [FileDownloadFunction]
  */
+@Serializable
 data class FileDownloadQuery(
     override val objectType: String,
     override val objectId: String,


### PR DESCRIPTION
feat(file-domain): add @Serializable annotation to FileDeleteCommand and FileDownloadQuery data classes

The @Serializable annotation is added to the FileDeleteCommand and FileDownloadQuery data classes to enable serialization and deserialization of these classes for use in serialization frameworks like kotlinx.serialization. This allows for easier data interchange between different parts of the application or with external systems.