### PR TITLE
refactor(MinioItemExtension.kt): refactor sanitizedMetadata function to handle nullable values

### DIFF
--- a/fs-s2/file/fs-file-app/src/main/kotlin/io/komune/fs/s2/file/app/model/MinioItemExtension.kt
+++ b/fs-s2/file/fs-file-app/src/main/kotlin/io/komune/fs/s2/file/app/model/MinioItemExtension.kt
@@ -23,4 +23,6 @@ suspend fun Item.toFile(buildUrl: suspend (FilePath) -> String): File {
 
 fun Item.sanitizedMetadata() = userMetadata().orEmpty().sanitizedMetadata()
 
-fun Map<String, String>.sanitizedMetadata() = this.mapKeys { (key) -> key.lowercase().removePrefix("x-amz-meta-") }
+fun Map<String, String?>.sanitizedMetadata(): Map<String, String> = this
+    .mapKeys { (key) -> key.lowercase().removePrefix("x-amz-meta-") }
+    .filterValues { it != null } as Map<String, String>


### PR DESCRIPTION
The sanitizedMetadata function in MinioItemExtension.kt has been refactored to handle nullable values. The function now explicitly defines the input map as containing nullable String values and filters out any null values before returning the sanitized metadata map. This change ensures that only non-null key-value pairs are included in the sanitized metadata map, improving the reliability and consistency of the function.