### PR TITLE
ci(dev.yml): add on-tag trigger for publishing and promoting on tag creation

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,6 +35,7 @@ jobs:
       packages: write
     with:
       make-file: 'docker.mk'
+      on-tag: 'publish promote'
       with-docker-registry-login: 'true'
     secrets:
       PKG_GITHUB_USERNAME: ${{ github.actor }}


### PR DESCRIPTION
By adding the `on-tag` trigger with the values 'publish promote', the workflow will now be triggered when a new tag is created. This will allow for automatic publishing and promoting of the packages when a new tag is pushed to the repository.