### PR TITLE
The import paths for `F2DefaultJson`

### DIFF
--- a/fs-infra/kb/fs-kb-client/src/main/kotlin/io/komune/fs/commons/kb/KbClient.kt
+++ b/fs-infra/kb/fs-kb-client/src/main/kotlin/io/komune/fs/commons/kb/KbClient.kt
@@ -5,8 +5,7 @@ import io.komune.fs.commons.kb.domain.command.VectorAskedEventDTOBase
 import io.komune.fs.commons.kb.domain.command.VectorCreateFunction
 import f2.client.F2Client
 import f2.client.ktor.F2ClientBuilder
-import f2.client.ktor.get
-import f2.client.ktor.http.F2DefaultJson
+import f2.client.ktor.common.F2DefaultJson
 import f2.client.ktor.http.HttpF2Client
 import f2.dsl.fnc.F2Function
 import f2.dsl.fnc.F2SupplierSingle

--- a/fs-s2/file/fs-file-client/src/main/kotlin/io/komune/fs/s2/file/client/Client.kt
+++ b/fs-s2/file/fs-file-client/src/main/kotlin/io/komune/fs/s2/file/client/Client.kt
@@ -1,8 +1,7 @@
 package io.komune.fs.s2.file.client
 
-import f2.client.ktor.http.F2DefaultJson
+import f2.client.ktor.common.F2DefaultJson
 import f2.client.ktor.http.plugin.F2Auth
-import f2.client.ktor.http.plugin.model.AuthRealm
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body


### PR DESCRIPTION
The import paths for `F2DefaultJson` are updated to `f2.client.ktor.common.F2DefaultJson` to align with the new module structure.