### PR TITLE
chore(build.gradle.kts): update dependencies version from 0.22.0-SNAPSHOT to 0.23.0-SNAPSHOT

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-	implementation("io.komune.fixers.gradle:dependencies:0.22.0-SNAPSHOT")
+	implementation("io.komune.fixers.gradle:dependencies:0.23.0-SNAPSHOT")
 }
 
 repositories {


### PR DESCRIPTION
The dependencies version is updated to the latest snapshot to incorporate recent improvements and bug fixes, ensuring the project benefits from the latest features and stability enhancements.