### PR TITLE
feat(ci): normalize secrets to FIXERS_PUBLISH_* namespace

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,8 +60,7 @@ jobs:
       storybook-static-dir: storybook-static
       with-setup-npm-github-pkg: 'false'
     secrets:
-      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
+      FIXERS_CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,6 +60,7 @@ jobs:
       storybook-static-dir: storybook-static
       with-setup-npm-github-pkg: 'false'
     secrets:
+      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       FIXERS_CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,13 +20,13 @@ jobs:
     with:
       make-file: 'infra/make/libs.mk'
     secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 
   docker:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
@@ -38,12 +38,12 @@ jobs:
       with-stage-docker-registry-login: 'true'
       with-promote-docker-registry-login: 'true'
     secrets:
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
-      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.FIXERS_DOCKER_HUB_PASSWORD }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
@@ -60,9 +60,9 @@ jobs:
       storybook-static-dir: storybook-static
       with-setup-npm-github-pkg: 'false'
     secrets:
-      NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
-      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.FIXERS_DOCKER_HUB_PASSWORD }}

--- a/infra/docker/storybook/Dockerfile
+++ b/infra/docker/storybook/Dockerfile
@@ -8,11 +8,11 @@ COPY storybook ./storybook
 
 WORKDIR /app/storybook
 
-ARG NPM_AUTH_TOKEN
+ARG FIXERS_PUBLISH_NPM_GITHUB_TOKEN
 RUN printf "\
 @komune-io:registry=https://npm.pkg.github.com\n\
 //npm.pkg.github.com/:_authToken=%s\n\
-" "${NPM_AUTH_TOKEN}" > .npmrc
+" "${FIXERS_PUBLISH_NPM_GITHUB_TOKEN}" > .npmrc
 
 
 RUN if [ ! -d "./storybook-static" ]; then \

--- a/infra/docker/storybook/Dockerfile
+++ b/infra/docker/storybook/Dockerfile
@@ -1,4 +1,4 @@
-#### Stage 1: Build the react application
+#### Stage 1: Build the Storybook static site
 FROM node:21.7-alpine3.19 as build
 
 WORKDIR /app
@@ -22,7 +22,7 @@ RUN if [ ! -d "./storybook-static" ]; then \
 
 FROM nginx:1.25.4-alpine
 
-LABEL org.opencontainers.image.source="https://github.com/komune-io/fixers-f2"
+LABEL org.opencontainers.image.source="https://github.com/komune-io/connect-fs"
 
 COPY --from=build /app/storybook/storybook-static /var/www
 COPY infra/docker/storybook/nginx.conf /etc/nginx/nginx.conf

--- a/infra/make/docs.mk
+++ b/infra/make/docs.mk
@@ -26,7 +26,7 @@ lint-docker-storybook:
 
 package-storybook:
 	@docker build --no-cache  --platform=linux/amd64 \
-		--build-arg NPM_AUTH_TOKEN=${NPM_AUTH_TOKEN} \
+		--build-arg FIXERS_PUBLISH_NPM_GITHUB_TOKEN=${FIXERS_PUBLISH_NPM_GITHUB_TOKEN} \
 		-f ${STORYBOOK_DOCKERFILE} \
 		-t ${STORYBOOK_IMG} .
 

--- a/infra/make/libs.mk
+++ b/infra/make/libs.mk
@@ -15,7 +15,7 @@ test:
 	./gradlew test
 
 #check:
-	#./gradlew sonar -Dsonar.token=${SONAR_TOKEN} -Dorg.gradle.parallel=true
+	#./gradlew sonar -Dsonar.token=${FIXERS_SONAR_TOKEN} -Dorg.gradle.parallel=true
 
 stage:
 	VERSION=$(VERSION) ./gradlew stage


### PR DESCRIPTION
## Summary
- Rename libs + docker + docs caller pass-throughs + storybook Dockerfile/docs.mk NPM_AUTH_TOKEN rename
- Hard cutover: no legacy fallback

## Depends on
- komune-io/fixers-gradle#162 (fix/normalize-secrets) must merge first

## Test plan
- [ ] CI green after org secrets are created under FIXERS_* names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized secret naming across CI/CD workflows and build tooling to streamline credential handling.
  * Updated build-time package auth argument and associated build invocations used for generating the Storybook site.
  * Adjusted container image metadata used for the Storybook build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->